### PR TITLE
track lexer position in input to improve error message

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,7 +8,7 @@ import (
 )
 
 type parser struct {
-	in <-chan item
+	in  <-chan item
 	cur *item
 }
 
@@ -330,7 +330,7 @@ func (p *parser) assign() (*Assign, error) {
 	}
 
 	return &Assign{
-		Dst: dst,
+		Dst:  dst,
 		Body: expr,
 	}, nil
 }
@@ -387,7 +387,7 @@ func (p *parser) node() (*Node, error) {
 	if err != nil {
 		return nil, err
 	} else if len(outParams) == 0 {
-		return nil, fmt.Errorf("minilustre: '%v' doesn't have any out parameter")
+		return nil, fmt.Errorf("minilustre: '%v' doesn't have any out parameter", name)
 	}
 	if _, err := p.acceptItem(itemRparen); err != nil {
 		return nil, err
@@ -417,11 +417,11 @@ func (p *parser) node() (*Node, error) {
 	}
 
 	return &Node{
-		Name: name,
-		InParams: inParams,
-		OutParams: outParams,
+		Name:        name,
+		InParams:    inParams,
+		OutParams:   outParams,
 		LocalParams: localParams,
-		Body: body,
+		Body:        body,
 	}, nil
 }
 
@@ -457,7 +457,8 @@ func Parse(r io.Reader) (*File, error) {
 		done <- err
 
 		// Consume all tokens
-		for range items {}
+		for range items {
+		}
 	}()
 
 	if err := l.lex(); err != nil {

--- a/parser.go
+++ b/parser.go
@@ -447,7 +447,7 @@ func Parse(r io.Reader) (*File, error) {
 	items := make(chan item, 2)
 	done := make(chan error, 1)
 
-	l := lexer{bufio.NewReader(r), items}
+	l := lexer{in: bufio.NewReader(r), out: items}
 	p := parser{items, nil}
 
 	var f *File


### PR DESCRIPTION
I wanted to add this to troubleshoot another
issue I stumbled on when trying to run the
test cases (running make in the testdata dir).

Before the change.

	$ make
	go run ../cmd/minilustre <pendulum.mls >pendulum.ll
	panic: minilustre: unexpected character '.'

	goroutine 1 [running]:
	main.main()
		/home/u/goget/src/github.com/emersion/minilustre/cmd/minilustre/main.go:22 +0x234

After the change. Notice the added "at offset 60".

	$ make
	go run ../cmd/minilustre <pendulum.mls >pendulum.ll
	panic: minilustre: unexpected character '.' at offset 60

	goroutine 1 [running]:
	main.main()
		/home/u/goget/src/github.com/emersion/minilustre/cmd/minilustre/main.go:22 +0x234

From this we can tell that the lexer gets stuck
when trying to lex "0.0", which is at offset 60
of pendulum.mls.

	x = 0.0 fby (t *. dx +. x);
		   ^
		   |
